### PR TITLE
add optional parameter for headers in middlewares

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ Express middleware supports the following properties:
 + `options`
   + `endpointUrl` [`string`] - the GraphQL endpoint url.
   + `displayOptions` [`object`] - same as [here](#Properties)
+  + `headersJS` [`string`, default `"{}"`] - object of headers serialized in string to be used on endpoint url
+	+ You can also use any JS expression which results in an object with header names as keys and strings as values e.g. `{ Authorization: localStorage['Meteor.loginToken'] }`
 
 #### Usage
 ```js
@@ -157,6 +159,8 @@ Hapi middleware supports the following properties:
   + `voyagerOptions`
       + `endpointUrl` [`string`] - the GraphQL endpoint url.
       + `displayOptions` [`object`] - same as [here](#Properties)
+	  + `headersJS` [`string`, default `"{}"`] - object of headers serialized in string to be used on endpoint url
+	    + You can also use any JS expression which results in an object with header names as keys and strings as values e.g. `{ Authorization: localStorage['Meteor.loginToken'] }`
 
 #### Usage
 ```js
@@ -186,6 +190,8 @@ Koa middleware supports the following properties:
 + `options`
   + `endpointUrl` [`string`] - the GraphQL endpoint url.
   + `displayOptions` [`object`] - same as [here](#Properties)
+  + `headersJS` [`string`, default `"{}"`] - object of headers serialized in string to be used on endpoint url
+	+ You can also use any JS expression which results in an object with header names as keys and strings as values e.g. `{ Authorization: localStorage['Meteor.loginToken'] }`
 
 #### Usage
 ```js

--- a/src/middleware/render-voyager-page.ts
+++ b/src/middleware/render-voyager-page.ts
@@ -2,10 +2,12 @@ export interface MiddlewareOptions {
   endpointUrl: string;
   version: string;
   displayOptions: object;
+  headersJS?: string;
 }
 
 export default function renderVoyagerPage(options: MiddlewareOptions) {
   const { version, endpointUrl, displayOptions } = options;
+  const headersJS = options.headersJS ? options.headersJS : '{}';
   return `
 <!DOCTYPE html>
 <html>
@@ -40,10 +42,10 @@ export default function renderVoyagerPage(options: MiddlewareOptions) {
       function introspectionProvider(introspectionQuery) {
         return fetch('${endpointUrl}', {
           method: 'post',
-          headers: {
+          headers: Object.assign({}, {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
-          },
+          }, ${headersJS}),
           body: JSON.stringify({query: introspectionQuery }),
           credentials: 'include',
         }).then(function (response) {


### PR DESCRIPTION
Similar usage as in [Apollo Server - GraphiQL](https://github.com/apollographql/apollo-server/blob/master/packages/apollo-server-module-graphiql/src/renderGraphiQL.ts)

Having secured GraphQL endpoint on dev server we would like to pass some headers (for example `Authorization`) to our endpoint.