### PR TITLE
fix calling next express middleware after finished request

### DIFF
--- a/src/middleware/express.ts
+++ b/src/middleware/express.ts
@@ -17,11 +17,10 @@ const express: Register = function voyagerExpress(options) {
     version,
   };
 
-  return (_req, res, next) => {
+  return (_req, res) => {
     res.setHeader('Content-Type', 'text/html');
     res.write(renderVoyagerPage(middlewareOptions));
     res.end();
-    next();
   };
 };
 


### PR DESCRIPTION
It can cause an error with sending headers in some of following middlewares (like not found error middleware)