### PR TITLE
ability to include credentials when using url querystring param

### DIFF
--- a/src/components/settings/SchemaModal.tsx
+++ b/src/components/settings/SchemaModal.tsx
@@ -62,8 +62,8 @@ class SchemaModal extends React.Component<SchemaModalProps, SchemaModalState> {
     let url = getQueryParams()['url'];
     if (url) {
       this.props.dispatch(hideSchemaModal());
-      const includeCredentials = getQueryParams()['includeCredentials'] === 'true';
-      const clientOptions = includeCredentials ? { credentials: 'include', mode: 'cors' } : {};
+      const withCredentials = getQueryParams()['withCredentials'] === 'true';
+      const clientOptions = withCredentials ? { credentials: 'include', mode: 'cors' } : {};
       const client = new GraphQLClient(url, clientOptions);
       client
         .request(introspectionQuery)

--- a/src/components/settings/SchemaModal.tsx
+++ b/src/components/settings/SchemaModal.tsx
@@ -15,7 +15,7 @@ import { StateInterface } from '../../reducers';
 import ClipboardButton from 'react-clipboard.js';
 
 import { introspectionQuery } from 'graphql/utilities';
-import { request } from 'graphql-request';
+import { GraphQLClient } from 'graphql-request';
 
 import {
   changeSchema,
@@ -62,7 +62,11 @@ class SchemaModal extends React.Component<SchemaModalProps, SchemaModalState> {
     let url = getQueryParams()['url'];
     if (url) {
       this.props.dispatch(hideSchemaModal());
-      request(url, introspectionQuery)
+      const includeCredentials = getQueryParams()['includeCredentials'] === 'true';
+      const clientOptions = includeCredentials ? { credentials: 'include', mode: 'cors' } : {};
+      const client = new GraphQLClient(url, clientOptions);
+      client
+        .request(introspectionQuery)
         .then(introspection => this.props.dispatch(changeSchema({ data: introspection })))
         .catch(err => {
           this.props.dispatch(


### PR DESCRIPTION
This is partially a response to #4.

Currently, a user is able to use the querystring param `url=http://www.path.to/graphql/endpoint` to have GraphQL Voyager automatically POST the introspection query to that endpoint. This does not work when using a URL that requires an authentication cookie.

This PR allows you to optionally add the querystring param `includeCredentials=true`, which will add `{ credentials: 'include', mode: 'cors' }` to the request.

Full querystring example: `?url=http://www.path.to/graphql/endpoint&includeCredentials=true`