### PR TITLE
Open link on Logo to Github Repository in a tab

### DIFF
--- a/src/components/panel/TitleArea.css
+++ b/src/components/panel/TitleArea.css
@@ -2,7 +2,7 @@
 
 .title-area {
   padding: 0 var(--panel-spacing);
-  & > .logo {
+  & > a > .logo {
     padding: 20px 0;
     display: flex;
     align-items: center;
@@ -49,5 +49,10 @@
 
   & > .choosebutton {
     width: 100%;
+  }
+
+  & a, & a:hover {
+    text-decoration: none;
+    outline: none;
   }
 }

--- a/src/components/panel/TitleArea.css
+++ b/src/components/panel/TitleArea.css
@@ -2,7 +2,7 @@
 
 .title-area {
   padding: 0 var(--panel-spacing);
-  & > a > .logo {
+  & > .logo {
     padding: 20px 0;
     display: flex;
     align-items: center;
@@ -49,10 +49,5 @@
 
   & > .choosebutton {
     width: 100%;
-  }
-
-  & a, & a:hover {
-    text-decoration: none;
-    outline: none;
   }
 }

--- a/src/components/panel/TitleArea.tsx
+++ b/src/components/panel/TitleArea.tsx
@@ -19,12 +19,14 @@ class TitleArea extends React.Component<TitleAreaProps> {
     const { dispatch, _showChangeButton } = this.props;
     return (
       <div className="title-area">
-        <div className="logo">
-          <LogoIcon />
-          <h2 className="title">
-            <strong>GraphQL</strong> Voyager
-          </h2>
-        </div>
+        <a href="https://github.com/APIs-guru/graphql-voyager">
+          <div className="logo">
+            <LogoIcon />
+            <h2 className="title">
+              <strong>GraphQL</strong> Voyager
+            </h2>
+          </div>
+        </a>
         {_showChangeButton && (
           <Button
             className="choosebutton"

--- a/src/components/panel/TitleArea.tsx
+++ b/src/components/panel/TitleArea.tsx
@@ -19,14 +19,12 @@ class TitleArea extends React.Component<TitleAreaProps> {
     const { dispatch, _showChangeButton } = this.props;
     return (
       <div className="title-area">
-        <a href="https://github.com/APIs-guru/graphql-voyager">
-          <div className="logo">
-            <LogoIcon />
-            <h2 className="title">
-              <strong>GraphQL</strong> Voyager
-            </h2>
-          </div>
-        </a>
+        <div className="logo">
+          <LogoIcon />
+          <h2 className="title">
+            <strong>GraphQL</strong> Voyager
+          </h2>
+        </div>
         {_showChangeButton && (
           <Button
             className="choosebutton"

--- a/src/components/panel/TitleArea.tsx
+++ b/src/components/panel/TitleArea.tsx
@@ -19,7 +19,7 @@ class TitleArea extends React.Component<TitleAreaProps> {
     const { dispatch, _showChangeButton } = this.props;
     return (
       <div className="title-area">
-        <a href="https://github.com/APIs-guru/graphql-voyager">
+        <a href="https://github.com/APIs-guru/graphql-voyager" target="_blank">
           <div className="logo">
             <LogoIcon />
             <h2 className="title">


### PR DESCRIPTION
I really like this library and want everyone to know about it. But it disrupts the user experience if a user is exploring a GraphQL API, accidentally clicks on the logo, and gets redirected to a GitHub repository.

I'd like for users to focus on the API that is being documented. I think the GraphQL Voyager logo is advertising enough without a link.