### PR TITLE
Added ability to toggle display of scalars

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ module system it is exported as `GraphQLVoyager` global variable.
   + `displayOptions.skipRelay` [`boolean`, default `true`] - skip relay-related entities
   + `displayOptions.rootType` [`string`] - name of the type to be used as a root
   + `displayOptions.sortByAlphabet` [`boolean`, default `false`] - sort fields on graph by alphabet
+  + `displayOptions.displayScalars` [`boolean`, default `true`] - display all scalars
   + `displayOptions.hideRoot` [`boolean`, default `false`] - hide the root type
 + `hideDocs` [`boolean`, default `false`] - hide the docs sidebar
 + `hideSettings` [`boolean`, default `false`] - hide settings panel

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ module system it is exported as `GraphQLVoyager` global variable.
   + `displayOptions.skipRelay` [`boolean`, default `true`] - skip relay-related entities
   + `displayOptions.rootType` [`string`] - name of the type to be used as a root
   + `displayOptions.sortByAlphabet` [`boolean`, default `false`] - sort fields on graph by alphabet
-  + `displayOptions.displayScalars` [`boolean`, default `true`] - display all scalars
+  + `displayOptions.showLeafFields` [`boolean`, default `true`] - show all scalars and enums
   + `displayOptions.hideRoot` [`boolean`, default `false`] - hide the root type
 + `hideDocs` [`boolean`, default `false`] - hide the docs sidebar
 + `hideSettings` [`boolean`, default `false`] - hide settings panel

--- a/example/webpack-example/index.jsx
+++ b/example/webpack-example/index.jsx
@@ -12,7 +12,7 @@ class Test extends React.Component {
 
   render() {
     return (
-      <Voyager introspection={this.introspectionProvider} displayOptions={{skipRelay: false}}/>
+      <Voyager introspection={this.introspectionProvider} displayOptions={{skipRelay: false, displayScalars: true}}/>
     )
   }
 

--- a/example/webpack-example/index.jsx
+++ b/example/webpack-example/index.jsx
@@ -12,7 +12,7 @@ class Test extends React.Component {
 
   render() {
     return (
-      <Voyager introspection={this.introspectionProvider} displayOptions={{skipRelay: false, displayScalars: true}}/>
+      <Voyager introspection={this.introspectionProvider} displayOptions={{skipRelay: false, showLeafFields: true}}/>
     )
   }
 

--- a/src/components/Voyager.tsx
+++ b/src/components/Voyager.tsx
@@ -33,7 +33,7 @@ type IntrospectionProvider = (query: string) => Promise<any>;
 export interface VoyagerDisplayOptions {
   rootType?: string;
   skipRelay?: boolean;
-  displayScalars?: boolean;
+  showLeafFields?: boolean;
   sortByAlphabet?: boolean;
   hideRoot?: boolean;
 }
@@ -63,7 +63,7 @@ export default class Voyager extends React.Component<VoyagerProps> {
       skipRelay: PropTypes.bool,
       sortByAlphabet: PropTypes.bool,
       hideRoot: PropTypes.bool,
-      displayScalars: PropTypes.bool,
+      showLeafFields: PropTypes.bool,
     }),
     hideDocs: PropTypes.bool,
     hideSettings: PropTypes.bool,

--- a/src/components/Voyager.tsx
+++ b/src/components/Voyager.tsx
@@ -33,6 +33,7 @@ type IntrospectionProvider = (query: string) => Promise<any>;
 export interface VoyagerDisplayOptions {
   rootType?: string;
   skipRelay?: boolean;
+  displayScalars?: boolean;
   sortByAlphabet?: boolean;
   hideRoot?: boolean;
 }
@@ -62,6 +63,7 @@ export default class Voyager extends React.Component<VoyagerProps> {
       skipRelay: PropTypes.bool,
       sortByAlphabet: PropTypes.bool,
       hideRoot: PropTypes.bool,
+      displayScalars: PropTypes.bool,
     }),
     hideDocs: PropTypes.bool,
     hideSettings: PropTypes.bool,

--- a/src/components/settings/Settings.tsx
+++ b/src/components/settings/Settings.tsx
@@ -58,6 +58,13 @@ export class Settings extends React.Component<SettingsProps> {
             onChange={event => onChange({ ...options, skipRelay: event.target.checked })}
           />
           <label htmlFor="skip">Skip Relay</label>
+          <Checkbox
+            id="displayScalars"
+            color="primary"
+            checked={!!options.displayScalars}
+            onChange={event => onChange({ ...options, displayScalars: event.target.checked })}
+          />
+          <label htmlFor="displayScalars">Display scalars</label>
         </div>
       </div>
     );

--- a/src/components/settings/Settings.tsx
+++ b/src/components/settings/Settings.tsx
@@ -59,12 +59,12 @@ export class Settings extends React.Component<SettingsProps> {
           />
           <label htmlFor="skip">Skip Relay</label>
           <Checkbox
-            id="displayScalars"
+            id="showLeafFields"
             color="primary"
-            checked={!!options.displayScalars}
-            onChange={event => onChange({ ...options, displayScalars: event.target.checked })}
+            checked={!!options.showLeafFields}
+            onChange={event => onChange({ ...options, showLeafFields: event.target.checked })}
           />
-          <label htmlFor="displayScalars">Display scalars</label>
+          <label htmlFor="showLeafFields">Show leaf fields</label>
         </div>
       </div>
     );

--- a/src/graph/type-graph.ts
+++ b/src/graph/type-graph.ts
@@ -60,3 +60,5 @@ export const getTypeGraphSelector = createSelector(
   state => state.displayOptions.hideRoot,
   getTypeGraph,
 );
+
+export const getDisplayOptions = state => state.displayOptions;

--- a/src/introspection/introspection.ts
+++ b/src/introspection/introspection.ts
@@ -253,5 +253,6 @@ export const getSchemaSelector = createSelector(
   (state: StateInterface) => state.schema,
   (state: StateInterface) => state.displayOptions.sortByAlphabet,
   (state: StateInterface) => state.displayOptions.skipRelay,
+  (state: StateInterface) => state.displayOptions.displayScalars,
   getSchema,
 );

--- a/src/introspection/introspection.ts
+++ b/src/introspection/introspection.ts
@@ -253,6 +253,6 @@ export const getSchemaSelector = createSelector(
   (state: StateInterface) => state.schema,
   (state: StateInterface) => state.displayOptions.sortByAlphabet,
   (state: StateInterface) => state.displayOptions.skipRelay,
-  (state: StateInterface) => state.displayOptions.displayScalars,
+  (state: StateInterface) => state.displayOptions.showLeafFields,
   getSchema,
 );

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -8,6 +8,7 @@ export type DisplayOptions = {
   rootTypeId?: string;
   skipRelay: boolean;
   sortByAlphabet: boolean;
+  displayScalars: boolean;
   hideRoot: boolean;
 };
 
@@ -47,6 +48,7 @@ const initialState: StateInterface = {
     rootTypeId: undefined,
     skipRelay: true,
     sortByAlphabet: false,
+    displayScalars: true,
     hideRoot: false,
   },
   selected: {

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -8,7 +8,7 @@ export type DisplayOptions = {
   rootTypeId?: string;
   skipRelay: boolean;
   sortByAlphabet: boolean;
-  displayScalars: boolean;
+  showLeafFields: boolean;
   hideRoot: boolean;
 };
 
@@ -48,7 +48,7 @@ const initialState: StateInterface = {
     rootTypeId: undefined,
     skipRelay: true,
     sortByAlphabet: false,
-    displayScalars: true,
+    showLeafFields: true,
     hideRoot: false,
   },
   selected: {


### PR DESCRIPTION
When using voyager for understanding larger graphs it's sometimes useful to hide the scalars. Please let me know your thoughts on this change.

Added an option to toggle display of leaf fields
![image](https://user-images.githubusercontent.com/1210516/44308283-dde6b700-a3f5-11e8-9992-14fef230ad1c.png)

When leaf fields are hidden it becomes a bit more easier to navigate and understand the connection between the edges.
![image](https://user-images.githubusercontent.com/1210516/44308291-0ec6ec00-a3f6-11e8-8510-4fa4188121c8.png)

As part of this change the displayOptions are accessible within the dot generation logic, and we could take this a step further and extend with much more awesome display options as well.
