### PR TITLE
Set up zoom later

### DIFF
--- a/src/graph/viewport.ts
+++ b/src/graph/viewport.ts
@@ -22,8 +22,10 @@ export class Viewport {
     this.container.innerHTML = '';
     this.$svg = stringToSvg(svgString);
     this.container.appendChild(this.$svg);
-
-    this.enableZoom();
+    
+    // Allow the SVG dimensions to be computed
+    // Quick fix for SVG manipulation issues.
+    setTimeout(() => this.enableZoom(), 0);
     this.bindClick();
     this.bindHover();
 


### PR DESCRIPTION
We are having a crash with the error

```
DOMException: Failed to execute 'inverse' on 'SVGMatrix': The matrix is not invertible.
    at SvgPanZoom.push../node_modules/svg-pan-zoom/src/svg-pan-zoom.js.SvgPanZoom.zoomAtPoint 
    at SvgPanZoom.push../node_modules/svg-pan-zoom/src/svg-pan-zoom.js.SvgPanZoom.zoom
    at SvgPanZoom.push../node_modules/svg-pan-zoom/src/svg-pan-zoom.js.SvgPanZoom.publicZoom
    at Object.zoom
    at Viewport.enableZoom
    at new Viewport
```

This "hack" prevents the issue.