### PR TITLE
[]deploy to heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: npm start --prefix example

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ _[GraphQL Weekly #42](https://graphqlweekly.com/issues/42)_
 ## [Live Demo](https://apis.guru/graphql-voyager/)
 [![voyager demo](./docs/demo-gif.gif)](https://apis.guru/graphql-voyager/)
 
+## Running on Cloud
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
 ## Features
   + Quick navigation on graph
   + Left panel which provides more detailed information about every type

--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@ _[GraphQL Weekly #42](https://graphqlweekly.com/issues/42)_
 ## [Live Demo](https://apis.guru/graphql-voyager/)
 [![voyager demo](./docs/demo-gif.gif)](https://apis.guru/graphql-voyager/)
 
-## Running on Cloud
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
-
 ## Features
   + Quick navigation on graph
   + Left panel which provides more detailed information about every type

--- a/app.json
+++ b/app.json
@@ -1,0 +1,10 @@
+{
+  "name": "graphql-voyager-example",
+  "description": "GraphQL introspection viewer example",
+  "website": "https://github.com/APIs-guru/graphql-voyager.git",
+  "buildpacks": [
+    {
+      "url": "heroku/nodejs"
+    }
+  ]
+}

--- a/app.json
+++ b/app.json
@@ -2,6 +2,7 @@
   "name": "graphql-voyager-example",
   "description": "GraphQL introspection viewer example",
   "website": "https://github.com/APIs-guru/graphql-voyager.git",
+  "repository": "https://github.com/bdcorps/graphql-voyager/tree/master/",
   "buildpacks": [
     {
       "url": "heroku/nodejs"

--- a/app.json
+++ b/app.json
@@ -2,7 +2,6 @@
   "name": "graphql-voyager-example",
   "description": "GraphQL introspection viewer example",
   "website": "https://github.com/APIs-guru/graphql-voyager.git",
-  "repository": "https://github.com/bdcorps/graphql-voyager/tree/9-deploy-to-heroku/",
   "buildpacks": [
     {
       "url": "heroku/nodejs"

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "name": "graphql-voyager-example",
   "description": "GraphQL introspection viewer example",
   "website": "https://github.com/APIs-guru/graphql-voyager.git",
-  "repository": "https://github.com/bdcorps/graphql-voyager/tree/master/",
+  "repository": "https://github.com/bdcorps/graphql-voyager/tree/9-deploy-to-heroku/",
   "buildpacks": [
     {
       "url": "heroku/nodejs"

--- a/example/README.md
+++ b/example/README.md
@@ -1,6 +1,8 @@
 Example GraphQL-Voyager Install
 ========================
 
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
 ------
 **Attribution:** the contents of this folder was copied from [GraphiQL](https://github.com/graphql/graphiql/tree/master/example) example and modified for GraphQL-Voyager example. See copyright below:
 

--- a/example/README.md
+++ b/example/README.md
@@ -20,3 +20,7 @@ installing and starting the example.
 3. `npm install`
 4. `npm start`
 5. Open your browser to the address listed in your console. e.g. `Started on http://localhost:49811/`
+
+## Running on Cloud
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/bdcorps/graphql-voyager/tree/9-deploy-to-heroku)

--- a/example/README.md
+++ b/example/README.md
@@ -1,10 +1,8 @@
 Example GraphQL-Voyager Install
 ========================
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
-
 ------
-**Attribution:** the contents of this folder was copied from [GraphiQL](https://github.com/graphql/graphiql/tree/master/example) example and modified for GraphQL-Voyager example. See copyright below:
+**Attribution:** The contents of this folder were copied from [GraphiQL](https://github.com/graphql/graphiql/tree/master/example) example and modified for GraphQL-Voyager example. See copyright below:
 
 > Copyright (c) Facebook, Inc. All rights reserved. [LICENSE](https://github.com/graphql/graphiql/blob/master/LICENSE)
 
@@ -15,8 +13,14 @@ than depending on npm, so that it is easier to test new changes. In order to use
 the compiled version of GraphQL-Voyager, first run in the parent directory before
 installing and starting the example.
 
+## Running Locally
+
 1. Run `npm install && npm run build:release` in the parent directory
 2. Navigate to this directory (example) in Terminal
 3. `npm install`
 4. `npm start`
 5. Open your browser to the address listed in your console. e.g. `Started on http://localhost:49811/`
+
+## Running on Cloud
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)

--- a/example/README.md
+++ b/example/README.md
@@ -20,7 +20,3 @@ installing and starting the example.
 3. `npm install`
 4. `npm start`
 5. Open your browser to the address listed in your console. e.g. `Started on http://localhost:49811/`
-
-## Running on Cloud
-
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)

--- a/example/server.js
+++ b/example/server.js
@@ -3,11 +3,13 @@ const graphqlHTTP = require('express-graphql');
 
 const schema = require('./schema');
 
+var port = process.env.PORT || process.env.VCAP_APP_PORT || 3005;
+
 const app = express();
 app.use(express.static(__dirname));
 app.use('/graphql', graphqlHTTP(() => ({ schema })));
 
-app.listen(0, function() {
-  const port = this.address().port;
+
+app.listen(port, function() {
   console.log(`Started on http://localhost:${port}/`);
 });

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "deploy": "deploy-to-gh-pages --local --update demo-dist",
     "stats": "NODE_ENV=production webpack --json --mode=production --config build/webpack.js > stats.json",
     "prettier": "prettier --write \"{,!(node_modules)/**/}*.{ts,tsx}\"",
-    "declarations": "tsc --emitDeclarationOnly -p tsconfig.lib.json"
+    "declarations": "tsc --emitDeclarationOnly -p tsconfig.lib.json",
+    "postinstall": "cd example && npm install"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
## Description
This adds a one-click button to deploy GraphQL example on Heroku. 

Fixes #9 

## Type of change
 - [x] New feature (non-breaking change which adds functionality)

## Notes
Change template URL in ./example/README.md Deploy button from `https://heroku.com/deploy?template=https://github.com/bdcorps/graphql-voyager/tree/9-deploy-to-heroku` to 
`https://heroku.com/deploy?template=https://github.com/APIs-guru/graphql-voyager/tree/master` to deploy the correct application source.