### PR TITLE
Implment possiblity to hide interface fields in object

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ module system it is exported as `GraphQLVoyager` global variable.
 + `displayOptions` _(optional)_
   + `displayOptions.skipRelay` [`boolean`, default `true`] - skip relay-related entities
   + `displayOptions.skipDeprecated` [`boolean`, default `true`] - skip deprecated fields and entities that contain only deprecated fields.
+  + `displayOptions.skipInterfaceFields` [`boolean`, default `false`] - skip fields that are inherited from interface
   + `displayOptions.rootType` [`string`] - name of the type to be used as a root
   + `displayOptions.sortByAlphabet` [`boolean`, default `false`] - sort fields on graph by alphabet
   + `displayOptions.showLeafFields` [`boolean`, default `true`] - show all scalars and enums

--- a/src/components/Voyager.tsx
+++ b/src/components/Voyager.tsx
@@ -23,6 +23,7 @@ export interface VoyagerDisplayOptions {
   rootType?: string;
   skipRelay?: boolean;
   skipDeprecated?: boolean;
+  skipInterfaceFields?: boolean;
   showLeafFields?: boolean;
   sortByAlphabet?: boolean;
   hideRoot?: boolean;
@@ -32,6 +33,7 @@ const defaultDisplayOptions = {
   rootType: undefined,
   skipRelay: true,
   skipDeprecated: true,
+  skipInterfaceFields: false,
   sortByAlphabet: false,
   showLeafFields: true,
   hideRoot: false,
@@ -130,6 +132,7 @@ export default class Voyager extends React.Component<VoyagerProps> {
       displayOptions.sortByAlphabet,
       displayOptions.skipRelay,
       displayOptions.skipDeprecated,
+      displayOptions.skipInterfaceFields,
     );
     const typeGraph = getTypeGraph(schema, displayOptions.rootType, displayOptions.hideRoot);
 

--- a/src/components/settings/Settings.tsx
+++ b/src/components/settings/Settings.tsx
@@ -50,6 +50,13 @@ export default class Settings extends React.Component<SettingsProps> {
             onChange={event => onChange({ showLeafFields: event.target.checked })}
           />
           <label htmlFor="showLeafFields">Show leaf fields</label>
+          <Checkbox
+            id="skipInterfaceFields"
+            color="primary"
+            checked={!!options.skipInterfaceFields}
+            onChange={event => onChange({ skipInterfaceFields: event.target.checked })}
+          />
+          <label htmlFor="skipInterfaceFields">Skip interface fields</label>
         </div>
       </div>
     );

--- a/src/graph/dot.ts
+++ b/src/graph/dot.ts
@@ -77,6 +77,7 @@ export function getDot(typeGraph, displayOptions): string {
         ${objectValues(node.fields, nodeField)}
         ${possibleTypes(node)}
         ${derivedTypes(node)}
+        ${interfacesTypes(node)}
       </TABLE>>
     `;
   }
@@ -142,6 +143,26 @@ function derivedTypes(node) {
     </TR>
     ${array(
       derivedTypes,
+      ({ id, type }) => `
+      <TR>
+        <TD ${HtmlId(id)} ALIGN="LEFT" PORT="${type.name}">${type.name}</TD>
+      </TR>
+    `,
+    )}
+  `;
+}
+
+function interfacesTypes(node) {
+  const interfacesTypes = node.interfaces;
+  if (_.isEmpty(interfacesTypes)) {
+    return '';
+  }
+  return `
+    <TR>
+      <TD>interfaces</TD>
+    </TR>
+    ${array(
+      interfacesTypes,
       ({ id, type }) => `
       <TR>
         <TD ${HtmlId(id)} ALIGN="LEFT" PORT="${type.name}">${type.name}</TD>

--- a/src/graph/svg-renderer.ts
+++ b/src/graph/svg-renderer.ts
@@ -125,6 +125,12 @@ function preprocessVizSVG(svgString: string) {
     $possibleType.querySelector('text').classList.add('type-link');
   });
 
+  forEachNode(svg, '.interface', $interface => {
+    // not sure if next line should be here it works without it
+    // $interface.classList.add('edge-source');
+    $interface.querySelector('text').classList.add('type-link');
+  });
+
   const serializer = new XMLSerializer();
   return serializer.serializeToString(svg);
 }

--- a/src/graph/type-graph.ts
+++ b/src/graph/type-graph.ts
@@ -20,6 +20,7 @@ export function getTypeGraph(schema, rootType: string, hideRoot: boolean) {
       ..._.values(type.fields),
       ...(type.derivedTypes || []),
       ...(type.possibleTypes || []),
+      ...(type.interfaces || []),
     ])
       .map('type')
       .filter(isNode)


### PR DESCRIPTION
Problem this PR tries to solve:
When you have interface with lot of common fields and multiple implementation of that interface currently all fields are shown for every implementation. That unnecessary make graph bigger than it needs to be. See this issue opened for this https://github.com/APIs-guru/graphql-voyager/issues/41

Solution:
I introduced new boolean in settings panel for hiding fields on objects that are from interface. Default settings is false to be compatible with current behavior. To be still able to tell what fields are available on object i added into graph information about what interfaces are implemented by object(currently it is available in side panel but not it graph itself)

Technical details:
Adding new settings is quite forward.

Then in `src/introspection/introspection.ts` i added function `markInterfaceFields` that traverse graph and delete fields from objects that are also present in interfaces.

Additionally in `src/graph/dot.ts` i added `interfacesTypes` function that is responsible for rendering (adding graphdot syntax string) list of interfaces that objects implement.

Last important part is in file `src/graph/type-graph.ts` which is responsible to decide what part of graph should be rendered from root type selected. Currently it search only forward from selected root. That present problem that when objects implement interface that is not reachable from root it is not shown in graph. This is kind of general problem but is really highlighted with this change because when you hide common field you will miss important part of graph(reachable fields are not shown anywhere). There are 2 solution for this problem:
 - allow back propagation from discovered nodes to interfaces and than normal forward propagation from discovered interfaces
 - allow back propagation from discovered nodes to interfaces but not do normal forward propagation from back visited interfaces only forward propagation to fields

Both solution ensure that all important details are shown in graph. I and my 2 coleages are more keen to first one. It is simpler to implement. It shows all information to navigate inside graph and small disadvantage that maybe it will show some nodes that you didn't ask for.

Small remark to authors code base was **amazing** to work with and i really enjoyed adding this feature. 

Picture for TLDR
![voyager-show-interface-fields](https://user-images.githubusercontent.com/5859040/70159941-fd245900-16b9-11ea-9cef-50a280e042af.png)
![voyager-hide-iterface-fields](https://user-images.githubusercontent.com/5859040/70159951-001f4980-16ba-11ea-8de7-e30e1dd7efdb.png)

