### PR TITLE
SvgPanZoom namespace workaround

### DIFF
--- a/src/graph/viewport.ts
+++ b/src/graph/viewport.ts
@@ -5,12 +5,26 @@ import * as animate from '@f/animate';
 import { removeClass, forEachNode, stringToSvg } from '../utils/';
 import { typeNameToId } from '../introspection';
 
+interface Point {
+  x: number;
+  y: number;
+}
+
+interface Instance {
+  resize(): Instance;
+  zoom(scale: number): void;
+  getPan(): Point;
+  getZoom(): number;
+  pan(point: Point): Instance;
+  destroy(): void;
+}
+
 export class Viewport {
   onSelectNode: (id: string) => void;
   onSelectEdge: (id: string) => void;
 
   $svg: SVGElement;
-  zoomer: SvgPanZoom.Instance;
+  zoomer: Instance;
   offsetLeft: number;
   offsetTop: number;
   maxZoom: number;

--- a/src/graph/viewport.ts
+++ b/src/graph/viewport.ts
@@ -5,6 +5,7 @@ import * as animate from '@f/animate';
 import { removeClass, forEachNode, stringToSvg } from '../utils/';
 import { typeNameToId } from '../introspection';
 
+// FIXME: we are waiting for this [PR](https://github.com/ariutta/svg-pan-zoom/pull/379), after that this two interfaces might be removed in favor to `import { Instance, Point } from 'svg-pan-zoom'`
 interface Point {
   x: number;
   y: number;


### PR DESCRIPTION
Hopefully will also fix #91 required for [graphql-faker voyager tab](https://github.com/APIs-guru/graphql-faker/issues/103)

While we are waiting for [PR](https://github.com/ariutta/svg-pan-zoom/pull/379) to dependency library there is an workaround

The problem is that in dependency there is outdated namespace way of declarations which indeed makes everything harder

Unfortunately we can not force other library to make es6 like modules

But there is an workaround - we just declare required interfaces and everything become working

How I did check this:

Prepared `test.json` with following content:

```json
{
  "extends": "./tsconfig.lib.json",
  "include": ["./typings/**/*.ts" ]
}
```

```bash
# cleanup everything
rm -rf dist middleware typings node_modules
# install dependencies
yarn
# build
yarn build:release
# test
.\node_modules\.bin\tsc --noEmit -p test.json
```

without this change we got:

```
typings/graph/viewport.d.ts:6:13 - error TS2503: Cannot find namespace 'SvgPanZoom'.

6     zoomer: SvgPanZoom.Instance;
              ~~~~~~~~~~

Found 1 error.
```

with them - everything is ok
