### PR TITLE
added displayOptions right type to MiddlewareOptions

### DIFF
--- a/src/components/Voyager.tsx
+++ b/src/components/Voyager.tsx
@@ -2,7 +2,7 @@ import { getIntrospectionQuery } from 'graphql/utilities';
 
 import { getSchema, extractTypeId } from '../introspection';
 import { SVGRender, getTypeGraph } from '../graph/';
-import { WorkerCallback } from '../utils/types';
+import { WorkerCallback, VoyagerDisplayOptions } from '../utils/types';
 
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
@@ -19,16 +19,7 @@ import './viewport.css';
 
 type IntrospectionProvider = (query: string) => Promise<any>;
 
-export interface VoyagerDisplayOptions {
-  rootType?: string;
-  skipRelay?: boolean;
-  skipDeprecated?: boolean;
-  showLeafFields?: boolean;
-  sortByAlphabet?: boolean;
-  hideRoot?: boolean;
-}
-
-const defaultDisplayOptions = {
+const defaultDisplayOptions: VoyagerDisplayOptions = {
   rootType: undefined,
   skipRelay: true,
   skipDeprecated: true,

--- a/src/middleware/render-voyager-page.ts
+++ b/src/middleware/render-voyager-page.ts
@@ -1,8 +1,9 @@
 const { version } = require('../package.json');
+import { VoyagerDisplayOptions } from '../utils/types';
 
 export interface MiddlewareOptions {
   endpointUrl: string;
-  displayOptions?: object;
+  displayOptions?: VoyagerDisplayOptions;
   headersJS?: string;
 }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -2,3 +2,12 @@ export type WorkerCallback = (
   path: string,
   relative: boolean,
 ) => Promise<Worker>;
+
+export interface VoyagerDisplayOptions {
+  rootType?: string;
+  skipRelay?: boolean;
+  skipDeprecated?: boolean;
+  showLeafFields?: boolean;
+  sortByAlphabet?: boolean;
+  hideRoot?: boolean;
+}


### PR DESCRIPTION
Replaced `object` type for MiddlewareOptions.displayOptions with right type `VoyagerDisplayOptions`. So IDE and compiler helps us now with it.